### PR TITLE
BaseNFT: Add MintPass Extension

### DIFF
--- a/contracts/factory/extensions/MintPassExtension.sol
+++ b/contracts/factory/extensions/MintPassExtension.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import "./NFTExtension.sol";
+import "./SaleControl.sol";
+
+contract MintPass is NFTExtension, Ownable, SaleControl {
+  uint256 public price;
+
+  uint256 public maxPerAddress;
+
+  // The address of ERC721 contract that is used for mint pass
+  address public mintPassAddress;
+
+  // For used tokenIds in the mint pass
+  mapping(uint256 => bool) usedTokenIds;
+
+  mapping(address => uint256) public claimedByAddress;
+
+  constructor(address _nft, address _mintPassAddress, uint256 _price, uint256 _maxPerAddress) NFTExtension(_nft) SaleControl() {
+    stopSale();
+    price = _price;
+    maxPerAddress = _maxPerAddress;
+    mintPassAddress = _mintPassAddress;
+  }  
+
+  function updatePrice(uint256 _price) public onlyOwner {
+    price = _price;
+  }
+
+  function updateMaxPerAddress(uint256 _maxPerAddress) public onlyOwner {
+    maxPerAddress = _maxPerAddress;
+  }
+
+  function updateMintPassAddress(address _mintPassAddress) public onlyOwner {
+    mintPassAddress = _mintPassAddress;
+  }
+
+  function mint(uint256 nTokens, uint256 mintPassTokenId) external whenSaleStarted payable {
+    super.beforeMint();
+
+    require(usedTokenIds[mintPassTokenId] == false, "This tokenId has already been used");
+
+    require(IERC721(mintPassAddress).ownerOf(mintPassTokenId) == msg.sender, "Does not have mint pass");
+
+    require(msg.value >= nTokens * price, "Not enough ETH to mint");
+
+    require(claimedByAddress[msg.sender] + nTokens <= maxPerAddress, "Cannot claim more per address");
+
+    usedTokenIds[mintPassTokenId] = true;
+    
+    claimedByAddress[msg.sender] += nTokens;
+
+    nft.mintExternal{ value: msg.value }(nTokens, msg.sender, bytes32(0x0));
+  }
+
+}

--- a/test/factory/MintPassTest.js
+++ b/test/factory/MintPassTest.js
@@ -1,0 +1,106 @@
+const assert = require("assert");
+const BigNumber = require("bignumber.js");
+
+const TemplateNFTv2 = artifacts.require("TemplateNFTv2");
+
+const MintPassExtension = artifacts.require("MintPassExtension");
+
+
+const ether = new BigNumber(1e18);
+
+contract("MintPass – Extension", (accounts) => {
+    let nft, extension;
+    const [owner, user1, user2] = accounts;
+
+    beforeEach(async () => {
+        nft = await TemplateNFTv2.new();
+        extension = await MintPassExtension.new(
+            nft.address,
+            nft.address,
+            1e14.toString(), // price
+            1, // max per address
+            {from: owner}
+        );
+    });
+
+    // it should deploy successfully
+    it("should deploy successfully", async () => {
+        assert.ok(nft.address);
+    });
+
+    // it should deploy extension successfully
+    it("should deploy extension successfully", async () => {
+        assert.ok(extension.address);
+    });
+
+    // it should connect extension
+    it("should connect extension", async () => {
+
+        await nft.addExtension(extension.address);
+
+        assert.equal(
+            await nft.isExtensionAllowed(extension.address),
+            true,
+        )
+    });
+
+    // should be possible to update price
+    it("should be possible to update price", async() => {
+        await extension.updatePrice(1e18.toString(), {from: owner});
+        let price = await extension.price.call().then(callback => {
+            return callback.toString();
+        })  
+        assert.equal(price, 1e18.toString());
+    }) 
+
+    // should be possible to update MaxPerAddress
+    it("should be possible to update maxPerAddress", async() => {
+        await extension.updateMaxPerAddress('10');
+        let maxPerAddress = await extension.maxPerAddress.call().then(callback => {
+            return callback.toString();
+        })  
+        assert.equal(maxPerAddress, '10');     
+    }) 
+    
+    // should be possible to update mintPassAddress
+    it("should be possible to update mintPassAddress", async() => {
+        await extension.updateMintPassAddress(user1, {from: owner});
+        let mintPassAddress = await extension.mintPassAddress.call().then(callback => {
+            return callback.toString();
+        })  
+        assert.equal(mintPassAddress, user1);
+    }) 
+
+
+    // should be possible to mint
+    it("should be possible to mint", async () => {
+        await nft.setBeneficiary(owner);
+        
+        await nft.flipSaleStarted({from: owner});
+        
+        await nft.mint(10, {from: user1, value: (ether.toString() + '0')});
+        
+        let balance = await nft.balanceOf(user1).then( balance => {
+            return balance.toString();
+        })
+        
+        // should mint 10 token
+        assert.equal(balance, '10');
+
+        // start sale
+        await extension.startSale();
+
+        await nft.addExtension(extension.address);
+
+        await extension.mint('1', '0', {from: user1, value: ether.toString()});
+
+        // totalSupply should be equal 11 (10 previous + 1)
+        await nft.totalSupply().then(callback => {
+            assert.equal(callback.toString(), '11');
+        })
+
+    })
+
+
+
+});

--- a/test/factory/MintPassTest.js
+++ b/test/factory/MintPassTest.js
@@ -19,6 +19,7 @@ contract("MintPass – Extension", (accounts) => {
             nft.address,
             1e14.toString(), // price
             1, // max per address
+            100, // max per extension
             {from: owner}
         );
     });
@@ -53,13 +54,13 @@ contract("MintPass – Extension", (accounts) => {
         assert.equal(price, 1e18.toString());
     }) 
 
-    // should be possible to update MaxPerAddress
-    it("should be possible to update maxPerAddress", async() => {
-        await extension.updateMaxPerAddress('10');
-        let maxPerAddress = await extension.maxPerAddress.call().then(callback => {
+    // should be possible to update maxPerToken
+    it("should be possible to update maxPerToken", async() => {
+        await extension.updateMaxPerToken('10');
+        let maxPerToken = await extension.maxPerToken.call().then(callback => {
             return callback.toString();
         })  
-        assert.equal(maxPerAddress, '10');     
+        assert.equal(maxPerToken, '10');     
     }) 
     
     // should be possible to update mintPassAddress
@@ -67,9 +68,32 @@ contract("MintPass – Extension", (accounts) => {
         await extension.updateMintPassAddress(user1, {from: owner});
         let mintPassAddress = await extension.mintPassAddress.call().then(callback => {
             return callback.toString();
-        })  
+        });
+
         assert.equal(mintPassAddress, user1);
     }) 
+
+    // should be possible to update nRemainingTokens
+    it("should be possible to update nRemainingTokens", async () => {
+        await extension.updateRemainingTokens('200', {from: owner});
+
+        let nRemainingTokens = await extension.nRemainingTokens.call().then(callback => {
+            return callback.toString();
+        });
+
+        assert.equal(nRemainingTokens, '200');
+    })
+
+    // should be possible to increase nRemainingTokens
+    it("should be possible to increase nRemainingTokens", async () => {
+        await extension.increaseRemainingTokens('200', {from: owner});
+
+        let nRemainingTokens = await extension.nRemainingTokens.call().then(callback => {
+            return callback.toString();
+        });
+
+        assert.equal(nRemainingTokens, '300');
+    })
 
 
     // should be possible to mint
@@ -97,8 +121,22 @@ contract("MintPass – Extension", (accounts) => {
         // totalSupply should be equal 11 (10 previous + 1)
         await nft.totalSupply().then(callback => {
             assert.equal(callback.toString(), '11');
-        })
+        });
 
+         // nRemainingTokens should be equal 9 (100 - 1 minted)
+         await extension.nRemainingTokens.call().then(callback => {
+            assert.equal(callback.toString(), '99');
+        });
+
+        try {
+            await extension.mint('1', '1', {from: user2, value: ether.toString()});
+        } 
+        catch {}
+
+        // should not be possible to mint without nft
+        await nft.totalSupply().then(callback => {
+            assert.equal(callback.toString(), '11');
+        });
     })
 
 


### PR DESCRIPTION
MintPass:

The mint pass extension here is a good way to give current holders preferential access to a new collection, but it’s not going to be a good way to manage groups from multiple collections in a “whitelist” manner

Also, you can deploy multiple extensions, each pointing to a different collection, and manage it like that with this extension.

So:
- contract A for new 10K collection
- extension A for 100 doodles holders 
- extension B for 100 punk holders
- extension X for N ABC holders


Overview:

1. Deploying BaseNFT contract A for some new collection
2. Deploying an extension X specifying which other contract the mint pass depends on
3. Connecting contract A and extension X

And then on the mint pass specifically:
- owners of some other collection can get 1 to N mints granted by the extension
- at a specific price
- there’s a mapping keeping track of which tokens have already minted their new NFTs so that one token from another collection can’t be passed around to mint multiple times?


BaseNFT (allowing mints from anyone, public sale) and MintPassExtension for the people who have a mint pass. – they both can be enabled at the same time.

For example:

1. I make a new 10K collection with its own contract
2. I want to allow any holder of my previous collection to mint for free (or for some arbitrary price)
3. I want to give 1 day (or some arbitrary timeframe) to the mint pass people to mint before opening up the public sale
4. Once public sale is open, anyone can mint (but if a mint pass holder mints, it would still be free for them, provided that the new collection hasn’t minted out yet)


cc @imatias