### PR TITLE
Fix broken test by updating exception message.

### DIFF
--- a/test/factory/extensions.js
+++ b/test/factory/extensions.js
@@ -193,7 +193,7 @@ contract("MetaverseBaseNFT – Extensions", (accounts) => {
 
         await expectRevert(
             ERC20Extension.mint(10, { from: user1 }),
-            "ERC20: transfer amount exceeds allowance"
+            "ERC20: insufficient allowance"
         );
         await expectRevert(
             ERC20Extension.mint(10, { from: user2 }),


### PR DESCRIPTION
Hi,

@afinetooth here.
aka. **JamesLemon** in Buildship Discord.

### There is one broken test in the test suite:

- **File**: test/factory/extensions.js:196
- **Test**: MetaverseBaseNFT – Extensions > it should allow to mint from ERC20SaleExtension:

Upon:

```
hh test test/factory/extensions.js
```

Results are:

<img width="611" alt="Screen Shot 2022-05-31 at 8 21 01 AM" src="https://user-images.githubusercontent.com/918667/171214670-949d04e1-defa-4faf-810b-4fee94d1da45.png">

And:

<img width="796" alt="Screen Shot 2022-05-31 at 8 21 14 AM" src="https://user-images.githubusercontent.com/918667/171214598-03f3df7a-fdb9-472f-846f-66e3eb391e15.png">

There is no specific reversion in the contract to handle the case being tested, so the exception message comes directly from the hardhat local network. 

But instead of:

```
ERC20: transfer amount exceeds allowance
```

The actual exception from hardhat appears to be:

```
ERC20: insufficient allowance
```

So I've simply changed the expected message in the test.

Maybe this is due to an environment discrepancy for me: hardhat version, Solidity version, etc. (Though I believe I'm using all the defaults for the project.)

But if you're getting this failure, this seems to be the fix.
