### PR TITLE
Pragma Fixed

### DIFF
--- a/contracts/DemoCollection.sol
+++ b/contracts/DemoCollection.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./ERC721Community.sol";
 

--- a/contracts/ERC721Community.sol
+++ b/contracts/ERC721Community.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/proxy/Proxy.sol";
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/ERC721CommunityBase.sol
+++ b/contracts/ERC721CommunityBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 /**
  * @title LICENSE REQUIREMENT

--- a/contracts/ERC721CommunityImplementation.sol
+++ b/contracts/ERC721CommunityImplementation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 /**
  * @title LICENSE REQUIREMENT

--- a/contracts/experiments/BurnNFT.sol
+++ b/contracts/experiments/BurnNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.2;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/experiments/GaslessNFT.sol
+++ b/contracts/experiments/GaslessNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity 0.8.9;
 
 import "../ERC721CommunityBase.sol";
 

--- a/contracts/extensions/DynamicPricePresaleListExtension.sol
+++ b/contracts/extensions/DynamicPricePresaleListExtension.sol
@@ -1,6 +1,6 @@
 
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";

--- a/contracts/extensions/ERC20SaleExtension.sol
+++ b/contracts/extensions/ERC20SaleExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/extensions/JSONTokenURIExtension.sol
+++ b/contracts/extensions/JSONTokenURIExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/contracts/extensions/LimitAmountSaleExtension.sol
+++ b/contracts/extensions/LimitAmountSaleExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/extensions/LimitedSupplyMintingExtension.sol
+++ b/contracts/extensions/LimitedSupplyMintingExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/extensions/MintBatchExtension.sol
+++ b/contracts/extensions/MintBatchExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/extensions/MintPassExtension.sol
+++ b/contracts/extensions/MintPassExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";

--- a/contracts/extensions/OffchainAllowListExtension.sol
+++ b/contracts/extensions/OffchainAllowListExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "hardhat/console.sol";
 

--- a/contracts/extensions/PresaleListExtension.sol
+++ b/contracts/extensions/PresaleListExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";

--- a/contracts/extensions/PublicSaleExtension.sol
+++ b/contracts/extensions/PublicSaleExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";

--- a/contracts/extensions/allowlist-factory/Allowlist.sol
+++ b/contracts/extensions/allowlist-factory/Allowlist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 //      Want to launch your own collection?
 //        Check out https://buildship.xyz

--- a/contracts/extensions/allowlist-factory/AllowlistFactory.sol
+++ b/contracts/extensions/allowlist-factory/AllowlistFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/contracts/extensions/allowlist-factory/base/NFTExtensionUpgradeable.sol
+++ b/contracts/extensions/allowlist-factory/base/NFTExtensionUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 

--- a/contracts/extensions/allowlist-factory/base/SaleControlUpgradeable.sol
+++ b/contracts/extensions/allowlist-factory/base/SaleControlUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/contracts/extensions/base/NFTExtension.sol
+++ b/contracts/extensions/base/NFTExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/contracts/extensions/base/SaleControl.sol
+++ b/contracts/extensions/base/SaleControl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/extensions/mocks/MockERC20CurrencyToken.sol
+++ b/contracts/extensions/mocks/MockERC20CurrencyToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 

--- a/contracts/extensions/mocks/MockTokenURIExtension.sol
+++ b/contracts/extensions/mocks/MockTokenURIExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/contracts/interfaces/IERC721Community.sol
+++ b/contracts/interfaces/IERC721Community.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/contracts/interfaces/INFTExtension.sol
+++ b/contracts/interfaces/INFTExtension.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/utils/Base64.sol
+++ b/contracts/utils/Base64.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9
 /// [MIT License]
 /// @title Base64
 /// @notice Provides a function for encoding some bytes in base64

--- a/contracts/utils/NextShuffler.sol
+++ b/contracts/utils/NextShuffler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2021 the ethier authors (github.com/divergencetech/ethier)
-pragma solidity >=0.8.9 <0.9.0;
+pragma solidity 0.8.9;
 
 import "@divergencetech/ethier/contracts/random/PRNG.sol";
 

--- a/contracts/utils/NextShufflerLazyInit.sol
+++ b/contracts/utils/NextShufflerLazyInit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 import "@divergencetech/ethier/contracts/random/PRNG.sol";
 import "./NextShuffler.sol";

--- a/contracts/utils/OpenseaProxy.sol
+++ b/contracts/utils/OpenseaProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.9;
 
 // These contract definitions are used to create a reference to the OpenSea
 // ProxyRegistry contract by using the registry's address (see isApprovedForAll).

--- a/contracts/utils/Rarible/ExchangeV1.sol
+++ b/contracts/utils/Rarible/ExchangeV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 // pragma solidity ^0.5.0;
 // pragma experimental ABIEncoderV2;
 


### PR DESCRIPTION
**Floating pragmas are considered a bad practice.**

It is always recommended that `pragma` should be fixed (not floating) to the version that you are intending to deploy your contracts with. 
I have fixed the pragma of the contracts to `0.8.9` as in the hardhat.config.ts solidity compiler version `0.8.9` is mentioned. 

For more information Check [this](https://www.oreilly.com/library/view/mastering-blockchain-programming/9781839218262/d1250994-b952-4d5e-9cde-1b852c18b55f.xhtml) out

Issue #71 Fixed :)

Thanks,
AB Dee.